### PR TITLE
add landing page template

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -5,6 +5,7 @@ import {
   decorateButtons,
   decorateIcons,
   decorateSections,
+  decorateTemplateAndTheme,
   getMetadata,
   loadBlock,
   loadBlocks,
@@ -66,7 +67,7 @@ export function decorateMain(main) {
  */
 async function loadEager(doc) {
   // document.documentElement.lang = 'en';
-  // decorateTemplateAndTheme();
+  decorateTemplateAndTheme();
   const main = doc.querySelector('main');
   if (main) {
     decorateMain(main);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -117,6 +117,13 @@ pre {
   overflow: scroll;
 }
 
+/* used as template for landing pages where full width is needed
+   landing page must include a template="landing" attribute in the
+   metadata section */
+body.landing main {
+  max-width: 100%;
+}
+
 main pre {
   background-color: var(--overlay-background-color);
   padding: 1em;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -117,12 +117,7 @@ pre {
   overflow: scroll;
 }
 
-/* used as template for landing pages where full width is needed
-   landing page must include a template="landing" attribute in the
-   metadata section */
-body.landing main {
-  max-width: 100%;
-}
+
 
 main pre {
   background-color: var(--overlay-background-color);
@@ -292,6 +287,13 @@ maybe use
 /* section metadata */
 main .section.highlight {
   background-color: var(--highlight-background-color);
+}
+
+/* used as template for landing pages where full width is needed
+   landing page must include a template="landing" attribute in the
+   metadata section */
+body.landing main {
+  max-width: 100%;
 }
 
 /* section equipamiento */

--- a/styles/weather/weather-icons-wind.css
+++ b/styles/weather/weather-icons-wind.css
@@ -4,6 +4,7 @@
   src: url('../font/weathericons-regular-webfont.eot?#iefix') format('embedded-opentype'), url('../font/weathericons-regular-webfont.woff2') format('woff2'), url('../font/weathericons-regular-webfont.woff') format('woff'), url('../font/weathericons-regular-webfont.ttf') format('truetype'), url('../font/weathericons-regular-webfont.svg#weather_iconsregular') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 .wi {
   display: inline-block;

--- a/styles/weather/weather-icons.css
+++ b/styles/weather/weather-icons.css
@@ -21,6 +21,7 @@
  */
 @font-face {
   font-family: 'weathericons';
+  font-display: swap;
   src: url('../font/weathericons-regular-webfont.eot');
   src: url('../font/weathericons-regular-webfont.eot?#iefix') format('embedded-opentype'), url('../font/weathericons-regular-webfont.woff2') format('woff2'), url('../font/weathericons-regular-webfont.woff') format('woff'), url('../font/weathericons-regular-webfont.ttf') format('truetype'), url('../font/weathericons-regular-webfont.svg#weather_iconsregular') format('svg');
   font-weight: normal;


### PR DESCRIPTION
Landing pages require full width to be available, this can be done now by setting `template=landing` in the metadata section of a page.

extra: adds `swap` display property to the weather font face.

Fix: https://fieitas.atlassian.net/browse/FIEITAS-66

Test URLs:
- Before: https://main--website--fieitas.hlx.page/drafts/ramirezc/landing
- After: https://landing--website--fieitas.hlx.page/drafts/ramirezc/landing
