### PR TITLE
hero + top section appear in two columns

### DIFF
--- a/blocks/sidebar/sidebar.css
+++ b/blocks/sidebar/sidebar.css
@@ -1,1 +1,28 @@
-/* empty css */
+
+
+/* top section spans across both the main content and the sidebar for desktop */
+@media (min-width: 768px) {
+    .has-sidebar .section.top {
+        grid-column: span 2;
+        padding: 0 16px;
+        text-align: center;
+    }
+
+    .has-sidebar .section.top h1{
+        font-size: 48px;
+        font-family: Montserrat, sans-serif;
+        font-weight: 700;
+        letter-spacing: -0.04em;
+    }
+
+    /* hero section spans across both the main content and the sidebar for desktop */
+    .has-sidebar .section.hero-container {
+        grid-column: span 2;
+        padding: 0 16px;
+    }
+}
+
+.sidebar .section {
+    padding: 0;
+    margin-top: 1em;
+}

--- a/blocks/sidebar/sidebar.css
+++ b/blocks/sidebar/sidebar.css
@@ -12,6 +12,7 @@
         font-size: 48px;
         font-family: Montserrat, sans-serif;
         font-weight: 700;
+        color: var(--text-secondary-color);
         letter-spacing: -0.04em;
     }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -17,7 +17,7 @@
   --background-color: #fff;
   --overlay-background-color: #eee;
   --highlight-background-color: #ccc;
-  --text-color: #1f1f1f;
+  --text-color: #6c6c6c;
 
   /* fonts */
   --body-font-family: 'Lato', helvetica, ubuntu, roboto, noto, sans-serif;
@@ -273,7 +273,7 @@ main .section.sidebar-container {
 
   main .section.sidebar-container {
     grid-column: 2;
-    grid-row: 1 / infinite;
+    grid-row: 2 / infinite;
   }
 }
 


### PR DESCRIPTION
There are several pages where there is a text centered OVER the main content and the sidebar. As discussed over Slack, we should also provide the possibility of have a Hero as well.

Fix: https://fieitas.atlassian.net/browse/FIEITAS-67

Title only example please look at `/es/campamento` URL  (no clue how to add the extra URL without the check going crazy)

Test URLs:

Before: https://main--website--fieitas.hlx.page/es/
After: https://hero-over-sidebar--website--fieitas.hlx.page/es/
