### PR TITLE
looks like franklin does not like underscores in path names

### DIFF
--- a/scripts/globals.js
+++ b/scripts/globals.js
@@ -1,7 +1,7 @@
 /* google drive is organized with a folder called /_secciones
    which contains footers, headers sidebars and fragments
  */
-const SECTION_URL = '_secciones';
+const SECTION_URL = 'secciones';
 const DEFAULT_LANG = 'es';
 
 export default { SECTION_URL, DEFAULT_LANG };


### PR DESCRIPTION
remove underscore from the path in dynamic loaded content

Test URLs:
- Before: https://main--website--fieitas.hlx.page/es
- After: https://fix-navigation-loading--website--fieitas.hlx.page/es
