### PR TITLE
fix: take full width for text box

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -130,6 +130,7 @@ main .hero-slider .carousel-item-image {
 /* hero slider text */
 main .hero-slider .carousel-item-text {
     position: absolute;
+    width: 100%;
     z-index: 1;
     background-color: rgb(0 0 0 / 50%);
     min-height: 188px;


### PR DESCRIPTION
just a quick fix, shorter sentences on hero would not fill the lower part of the screen.

Test URLs:
- Before: https://main--website--fieitas.hlx.live/es/portada
- After: https://w-fix--website--fieitas.hlx.live/es/portada
