### PR TITLE
contact form prints message instead of redirecting

### DIFF
--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -1,1 +1,39 @@
-/* placeholder */
+
+.form-wrapper{
+    position: relative;
+
+}
+
+.form-container .done-message.hidden{
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0s 2s, opacity 2s linear;
+}
+
+.form-container .done-message{
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.2s linear;
+    background-color: rgb(80 80 80 / 70%);
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0 ;
+    right: 0;
+    margin: 2rem;
+    padding: 2rem;
+    text-align: center;
+    display: table-cell;
+    vertical-align: middle
+}
+
+.form-container .done-message>p{
+    color: white;
+    position: absolute;
+    margin: 0;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 120%;
+}
+

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -63,7 +63,17 @@ function createButton(fd) {
         button.setAttribute('disabled', '');
         await submitForm(form);
         const redirectTo = fd.Extra;
-        window.location.href = redirectTo;
+        if (redirectTo !== '') {
+          window.location.href = redirectTo;
+        } else {
+          const done = form.querySelector('.done-message');
+          done.classList.remove('hidden');
+          setTimeout(() => {
+            done.classList.add('hidden');
+          }, 3000);
+        }
+        form.reset();
+        button.removeAttribute('disabled');
       }
     });
   }
@@ -132,6 +142,18 @@ function fill(form) {
   }
 }
 
+function createDoneMsg(fd) {
+  const msg = document.createElement('div');
+
+  msg.classList.add('hidden', 'done-message');
+
+  const text = document.createElement('p');
+  text.innerHTML += fd.Placeholder;
+  msg.append(text);
+
+  return msg;
+}
+
 async function createForm(formURL) {
   const { pathname, search } = new URL(formURL);
   const fetchUrl = pathname + search;
@@ -164,6 +186,9 @@ async function createForm(formURL) {
       case 'text-area':
         fieldWrapper.append(createLabel(fd));
         fieldWrapper.append(createTextArea(fd));
+        break;
+      case 'meta-done':
+        fieldWrapper.append(createDoneMsg(fd));
         break;
       case 'submit':
         fieldWrapper.append(createButton(fd));

--- a/styles/sections.css
+++ b/styles/sections.css
@@ -45,7 +45,8 @@ main input {
     margin-bottom: 1rem;
     padding: 0.75rem 0.6rem;
     border: 1px solid var(--accent-color);
-    color: var(--text-color)
+    color: var(--text-color);
+    box-sizing: border-box;
 }
 
 main textarea{


### PR DESCRIPTION
This PR changes how the contact form works by allowing to define a sentence to print once the form is submited, instead of navigate you to another page
![Snapshot_2023-06-02_at_16 59 27](https://github.com/fieitas/website/assets/1543913/cac140d6-8376-40af-ae9f-ab94b2c5dcb1)

Test URLs:
- Before: https://main--website--fieitas.hlx.page/es/contacto
- After: https://form-done-message--website--fieitas.hlx.page/es/contacto
